### PR TITLE
Make `error.format()` and sensitive mode more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,7 +795,7 @@ Options:
 
 ## Error messages
 
-**If you just use `error.message` you’re missing out!**
+**If you just use `error.message`, you’re missing out!**
 
 `error.message` example:
 
@@ -823,7 +823,7 @@ Got: number
 It’s helpful when errors show you the actual values that failed decoding to make it easier to understand what happened. However, if you’re dealing with sensitive data, such as email addresses, passwords or social security numbers, you might not want that data to potentially appear in error logs.
 
 - `error.message` hides potentially sensitive data so accidental uncaught errors don’t leak anything.
-- `error.format()` defaults to showing actual values. It also shows the “path” to the problematic value (which isn’t available at the time `error` is constructed, which is why `error.message` doesn’t contain the path.)
+- `error.format()` defaults to showing actual values. It also shows the “path” to the problematic value (which isn’t available at the time `error` is constructed, which is why `error.message` doesn’t contain the path).
 - `error.format({ sensitive: true })` can be used to hide potentially sensitive data. (See `ReprOptions`.)
 
 ## Tolerant decoding

--- a/README.md
+++ b/README.md
@@ -802,6 +802,7 @@ Options:
 ```
 Expected a string
 Got: number
+(Actual values are hidden in sensitive mode.)
 ```
 
 `error.format()` example:
@@ -818,6 +819,7 @@ Got: 123456789
 At root["details"]["ssn"]:
 Expected a string
 Got: number
+(Actual values are hidden in sensitive mode.)
 ```
 
 It’s helpful when errors show you the actual values that failed decoding to make it easier to understand what happened. However, if you’re dealing with sensitive data, such as email addresses, passwords or social security numbers, you might not want that data to potentially appear in error logs.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tiny-decoders ![no dependencies](https://img.shields.io/david/lydell/tiny-decoders.svg) [![minified size](https://img.shields.io/bundlephobia/min/tiny-decoders.svg)](https://bundlephobia.com/result?p=tiny-decoders)
+# tiny-decoders [![minified size](https://img.shields.io/bundlephobia/min/tiny-decoders.svg)](https://bundlephobia.com/result?p=tiny-decoders)
 
 Type-safe data decoding for the minimalist.
 
@@ -7,6 +7,12 @@ Type-safe data decoding for the minimalist.
 ```
 npm install tiny-decoders
 ```
+
+**Don’t miss out!**
+
+- 👉 [Decoders summary](#decoders)
+- 👉 [Optimal type annotations](#type-annotations)
+- 👉 [Great error messages](#error-messages)
 
 ## Example
 
@@ -47,6 +53,7 @@ try {
   const user: User = userDecoder(payload);
 } catch (error: unknown) {
   if (error instanceof DecoderError) {
+    // `error.format()` gives a nicer error message than `error.message`.
     console.error(error.format());
   } else {
     console.error(error);
@@ -483,7 +490,7 @@ function fieldsUnion<T extends Record<string, Decoder<unknown>>>(
 >;
 ```
 
-Decodes JSON objects with a common string field (that tells them apart) and a TypeScript union type.
+Decodes JSON objects with a common string field (that tells them apart) into a TypeScript union type.
 
 The `key` is the name of the common string field.
 
@@ -697,6 +704,7 @@ try {
   myDecoder(someUnknownValue);
 } catch (error) {
   if (error instanceof DecoderError) {
+    // `error.format()` gives a nicer error message than `error.message`.
     console.error(error.format());
   } else {
     console.error(error);
@@ -785,21 +793,38 @@ Options:
 | recurseMaxLength | `number` | `20` | Like `maxLength`, but when recursing. One typically wants shorter lengths here to avoid overly long error messages. |
 | sensitive | `boolean` | `false` | Set it do `true` if you deal with sensitive data to avoid leaks. See below. |
 
-## Sensitive data
+## Error messages
 
-By default, the tiny-decoder’s error messages try to be helpful by showing you the actual values that failed decoding to make it easier to understand what happened. However, if you’re dealing with sensitive data, such as email addresses, passwords or social security numbers, you might not want that data to potentially appear in error logs.
+**If you just use `error.message` you’re missing out!**
 
-Standard:
-
-```
-object["details"]["ssn"]: Expected a string, but got: 123456789
-```
-
-With `{ sensitive: true }` (in `ReprOptions`):
+`error.message` example:
 
 ```
-object["details"]["ssn"]: Expected a string, but got: number
+Expected a string
+Got: number
 ```
+
+`error.format()` example:
+
+```
+At root["details"]["ssn"]:
+Expected a string
+Got: 123456789
+```
+
+`error.format({ sensitive: true })` example:
+
+```
+At root["details"]["ssn"]:
+Expected a string
+Got: number
+```
+
+It’s helpful when errors show you the actual values that failed decoding to make it easier to understand what happened. However, if you’re dealing with sensitive data, such as email addresses, passwords or social security numbers, you might not want that data to potentially appear in error logs.
+
+- `error.message` hides potentially sensitive data so accidental uncaught errors don’t leak anything.
+- `error.format()` defaults to showing actual values. It also shows the “path” to the problematic value (which isn’t available at the time `error` is constructed, which is why `error.message` doesn’t contain the path.)
+- `error.format({ sensitive: true })` can be used to hide potentially sensitive data. (See `ReprOptions`.)
 
 ## Tolerant decoding
 

--- a/examples/readme.test.ts
+++ b/examples/readme.test.ts
@@ -135,6 +135,21 @@ test("default vs sensitive error messages", () => {
     },
   };
 
+  let message = "Expected userDecoder to fail!";
+  try {
+    userDecoder(data);
+  } catch (error) {
+    message =
+      error instanceof Error ? error.message : `Unknown error: ${repr(error)}`;
+  }
+
+  expect(message).toMatchInlineSnapshot(`
+    Expected a string
+    Got: number
+
+    For better error messages, see https://github.com/lydell/tiny-decoders#error-messages
+  `);
+
   expect(run(userDecoder, data)).toMatchInlineSnapshot(`
     At root["details"]["ssn"]:
     Expected a string

--- a/examples/readme.test.ts
+++ b/examples/readme.test.ts
@@ -146,6 +146,7 @@ test("default vs sensitive error messages", () => {
   expect(message).toMatchInlineSnapshot(`
     Expected a string
     Got: number
+    (Actual values are hidden in sensitive mode.)
 
     For better error messages, see https://github.com/lydell/tiny-decoders#error-messages
   `);
@@ -160,6 +161,7 @@ test("default vs sensitive error messages", () => {
     At root["details"]["ssn"]:
     Expected a string
     Got: number
+    (Actual values are hidden in sensitive mode.)
   `);
 });
 

--- a/examples/type-annotations.test.ts
+++ b/examples/type-annotations.test.ts
@@ -30,7 +30,7 @@ test("type annotations", () => {
     name: string,
     aye: number,
   });
-  // Since TypesCript has inferred legit decoders above, it marks the following
+  // Since TypeScript has inferred legit decoders above, it marks the following
   // two calls as errors (you can’t pass an object with `aye` as a `Person`),
   // while the _real_ errors of course are in the decoders themselves.
   // @ts-expect-error Property 'age' is missing in type '{ name: string; aye: number; }' but required in type 'Person'.

--- a/index.ts
+++ b/index.ts
@@ -617,12 +617,12 @@ export class DecoderError extends TypeError {
         ? params
         : { tag: "custom", message: params.message, got: params.value };
     super(
-      formatDecoderErrorVariant(
+      `${formatDecoderErrorVariant(
         variant,
         // Default to sensitive so accidental uncaught errors don’t leak
         // anything. Explicit `.format()` defaults to non-sensitive.
         { sensitive: true }
-      )
+      )}\n\nFor better error messages, see https://github.com/lydell/tiny-decoders#error-messages`
     );
     this.path = key === undefined ? [] : [key];
     this.variant = variant;

--- a/index.ts
+++ b/index.ts
@@ -540,7 +540,12 @@ function formatDecoderErrorVariant(
   variant: DecoderErrorVariant,
   options?: ReprOptions
 ): string {
-  const formatGot = (value: unknown): string => repr(value, options);
+  const formatGot = (value: unknown): string => {
+    const formatted = repr(value, options);
+    return options?.sensitive === true
+      ? `${formatted}\n(Actual values are hidden in sensitive mode.)`
+      : formatted;
+  };
 
   const stringList = (strings: Array<string>): string =>
     strings.length === 0

--- a/tests/DecoderError.test.ts
+++ b/tests/DecoderError.test.ts
@@ -25,6 +25,7 @@ describe("constructor", () => {
     expect(error.message).toMatchInlineSnapshot(`
       Expected a valid regex
       Got: string
+      (Actual values are hidden in sensitive mode.)
 
       For better error messages, see https://github.com/lydell/tiny-decoders#error-messages
     `);
@@ -65,6 +66,7 @@ describe("constructor", () => {
     expect(error.message).toMatchInlineSnapshot(`
       Expected a valid regex
       Got: string
+      (Actual values are hidden in sensitive mode.)
 
       For better error messages, see https://github.com/lydell/tiny-decoders#error-messages
     `);
@@ -189,6 +191,7 @@ describe("format", () => {
         At root:
         Expected a string
         Got: [string, Object(1), (1 more)]
+        (Actual values are hidden in sensitive mode.)
       `);
   });
 });

--- a/tests/DecoderError.test.ts
+++ b/tests/DecoderError.test.ts
@@ -25,6 +25,8 @@ describe("constructor", () => {
     expect(error.message).toMatchInlineSnapshot(`
       Expected a valid regex
       Got: string
+
+      For better error messages, see https://github.com/lydell/tiny-decoders#error-messages
     `);
     expect(error2.message).toBe(error.message);
 
@@ -63,6 +65,8 @@ describe("constructor", () => {
     expect(error.message).toMatchInlineSnapshot(`
       Expected a valid regex
       Got: string
+
+      For better error messages, see https://github.com/lydell/tiny-decoders#error-messages
     `);
     expect(error2.message).toBe(error.message);
 
@@ -113,7 +117,11 @@ describe("static at", () => {
     const error2 = DecoderError.at(error, 0);
     expect(error2).not.toBe(error);
     expect(error2).toBeInstanceOf(DecoderError);
-    expect(error2.message).toMatchInlineSnapshot(`something broke`);
+    expect(error2.message).toMatchInlineSnapshot(`
+      something broke
+
+      For better error messages, see https://github.com/lydell/tiny-decoders#error-messages
+    `);
     expect(error2.path).toStrictEqual([0]);
     expect(error2.variant).toStrictEqual({
       tag: "custom",
@@ -131,7 +139,11 @@ describe("static at", () => {
     const error2 = DecoderError.at(error, 0);
     expect(error2).not.toBe(error);
     expect(error2).toBeInstanceOf(DecoderError);
-    expect(error2.message).toMatchInlineSnapshot(`text,5`);
+    expect(error2.message).toMatchInlineSnapshot(`
+      text,5
+
+      For better error messages, see https://github.com/lydell/tiny-decoders#error-messages
+    `);
     expect(error2.path).toStrictEqual([0]);
     expect(error2.variant).toStrictEqual({
       tag: "custom",


### PR DESCRIPTION
Closes #14.

This adds `For better error messages, see https://github.com/lydell/tiny-decoders#error-messages` at the end of `DecoderError`’s `.message`. That points to a new section that compares and explains `.message`, `.format()` and `.format({ sensitive: true })`.

I’ve also updated the readme to make it easier to find `.format()`, as well as making a few other little tweaks.