### PR TITLE
Allow any values in the object of stringUnion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
   Removing this feature makes tiny-decoders easier to understand, and tinier, which is the goal.
 
+- Changed: `stringUnion` now accepts `Record<string, unknown>` instead of `Record<string, null>`. If you already have an object with the correct keys but non-null values, then it can be handy to be able to use that object.
+
 ### Version 6.0.1 (2022-02-20)
 
 - Improved: `.message` of `DecoderError`s now link to the docs, which point you to using `.format()` instead for better error messages.

--- a/README.md
+++ b/README.md
@@ -298,14 +298,16 @@ Decodes a JSON string into a TypeScript `string`.
 ### stringUnion
 
 ```ts
-function stringUnion<T extends Record<string, null>>(
+function stringUnion<T extends Record<string, unknown>>(
   mapping: T
 ): Decoder<keyof T>;
 ```
 
 Decodes a set of specific JSON strings into a TypeScript union of those strings.
 
-The `mapping` is an object where the keys are the strings you want and the values are always `null`. The keys must be strings (not numbers) and you must provide at least one key.
+The `mapping` is an object where the keys are the strings you want. The keys must be strings (not numbers) and you must provide at least one key.
+
+The values in the object can be anything – they don’t matter. The convention is to use `null` as values. If you already have an object with the correct keys but non-null values, then it can be handy to be able to use that object – that’s why any values are allowed. There’s an example of that in the [type inference file](examples/type-inference.test.ts).
 
 Example:
 

--- a/examples/type-inference.test.ts
+++ b/examples/type-inference.test.ts
@@ -375,3 +375,38 @@ test("making a type from a decoder – unions", () => {
       }
     `);
 });
+
+test("making a type from an object and stringUnion", () => {
+  // Imagine this being the popular `chalk` terminal coloring package.
+  const chalk = {
+    hex:
+      (hex: string) =>
+      (text: string): string =>
+        `${hex}:${text}`,
+  };
+
+  // An object with severity names and a corresponding color.
+  const SEVERITIES = {
+    Low: "007CBB",
+    Medium: "FFA500",
+    High: "E64524",
+    Critical: "FF0000",
+  } as const;
+
+  // Create a type from the object, for just the severity names.
+  type Severity = keyof typeof SEVERITIES;
+  expectType<TypeEqual<Severity, "Critical" | "High" | "Low" | "Medium">>(true);
+
+  // Make a decoder for the severity names out of the object.
+  // The values in the object passed to `stringUnion` are typically `null`,
+  // but this is a good use case for allowing other values (strings in this case).
+  const severityDecoder = stringUnion(SEVERITIES);
+  expectType<TypeEqual<Severity, ReturnType<typeof severityDecoder>>>(true);
+  expect(severityDecoder("High")).toBe("High");
+
+  // Use the object to to color text.
+  function coloredSeverity(severity: Severity): string {
+    return chalk.hex(SEVERITIES[severity])(severity);
+  }
+  expect(coloredSeverity("Low")).toBe("007CBB:Low");
+});

--- a/examples/type-inference.test.ts
+++ b/examples/type-inference.test.ts
@@ -404,7 +404,7 @@ test("making a type from an object and stringUnion", () => {
   expectType<TypeEqual<Severity, ReturnType<typeof severityDecoder>>>(true);
   expect(severityDecoder("High")).toBe("High");
 
-  // Use the object to to color text.
+  // Use the object to color text.
   function coloredSeverity(severity: Severity): string {
     return chalk.hex(SEVERITIES[severity])(severity);
   }

--- a/index.ts
+++ b/index.ts
@@ -37,14 +37,14 @@ export function string(value: unknown): string {
   return value;
 }
 
-export function stringUnion<T extends Record<string, null>>(
+export function stringUnion<T extends Record<string, unknown>>(
   mapping: keyof T extends string
     ? keyof T extends never
       ? "stringUnion must have at least one key"
       : T
     : {
         [P in keyof T]: P extends number
-          ? "stringUnion keys must be strings, not numbers"
+          ? ["stringUnion keys must be strings, not numbers", never]
           : T[P];
       }
 ): Decoder<keyof T> {

--- a/tests/decoders.test.ts
+++ b/tests/decoders.test.ts
@@ -155,10 +155,10 @@ describe("stringUnion", () => {
   });
 
   test("keys must be strings", () => {
-    // @ts-expect-error Type 'null' is not assignable to type '"stringUnion keys must be strings, not numbers"'.
+    // @ts-expect-error Type 'null' is not assignable to type '["stringUnion keys must be strings, not numbers", never]'.
     stringUnion({ 1: null });
-    // @ts-expect-error Type 'string' is not assignable to type 'null'.
-    stringUnion({ 1: "stringUnion keys must be strings, not numbers" });
+    // @ts-expect-error Type 'null' is not assignable to type 'never'.
+    stringUnion({ 1: ["stringUnion keys must be strings, not numbers", null] });
     const goodDecoder = stringUnion({ "1": null });
     expectType<TypeEqual<ReturnType<typeof goodDecoder>, "1">>(true);
     expect(goodDecoder("1")).toBe("1");


### PR DESCRIPTION
`stringUnion` takes an object, but only the keys are interesting. Currently, the type annotation requires all values to be `null`. (Ideally, `stringUnion` would take a tuple, but I haven’t been able to make that work type wise.)

@SimonAlling showed me a use case for having non-null values. This PR changes the type for the values from `null` to `unknown` (which means allowing any value), and adds his example as a test case.